### PR TITLE
APKファイルを開く際にインストール権限をチェックする

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <application
         android:name=".FolderViewerApplication"

--- a/app/src/main/java/net/matsudamper/folderviewer/MainActivity.kt
+++ b/app/src/main/java/net/matsudamper/folderviewer/MainActivity.kt
@@ -549,6 +549,19 @@ private fun FileBrowserEventHandler(
                             )
                         }
                     }
+                    val isApk = event.mimeType == "application/vnd.android.package-archive"
+                    if (isApk && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O &&
+                        !context.packageManager.canRequestPackageInstalls()
+                    ) {
+                        runCatching {
+                            context.startActivity(
+                                Intent(android.provider.Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES).apply {
+                                    data = android.net.Uri.parse("package:${context.packageName}")
+                                },
+                            )
+                        }
+                        return@collect
+                    }
                     val intent = Intent(Intent.ACTION_VIEW).apply {
                         setDataAndType(uri, event.mimeType ?: "*/*")
                         addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)


### PR DESCRIPTION
REQUEST_INSTALL_PACKAGES権限をManifestに追加し、APKを開く際に
canRequestPackageInstalls()で権限を確認する。未許可の場合は設定画面
に誘導することで、パッケージマネージャー選択後に先へ進めない問題を修正する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * APKファイルを外部アプリで開く際の処理を改善しました。Android 8.0以上のデバイスで、不明なソースからのアプリケーションインストール権限がない場合、システム設定画面へのアクセスを促すようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->