### PR TITLE
操作を開始する時のSnackbarに操作履歴への遷移ボタンを付ける

### DIFF
--- a/app/src/main/java/net/matsudamper/folderviewer/MainActivity.kt
+++ b/app/src/main/java/net/matsudamper/folderviewer/MainActivity.kt
@@ -646,6 +646,7 @@ private fun EntryProviderScope<NavKey>.fileBrowserEntry(navigator: Navigator) {
         FileBrowserScreen(
             uiState = uiStateValue,
             uiEvent = viewModel.uiEvent,
+            onNavigateToUploadProgress = { navigator.navigate(UploadProgress) },
         )
     }
 }

--- a/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileBrowserScreen.kt
+++ b/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileBrowserScreen.kt
@@ -3,6 +3,7 @@ package net.matsudamper.folderviewer.ui.browser
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
@@ -14,6 +15,7 @@ import kotlinx.coroutines.flow.Flow
 fun FileBrowserScreen(
     uiState: FileBrowserUiState,
     uiEvent: Flow<FileBrowserUiEvent>,
+    onNavigateToUploadProgress: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     BackHandler(enabled = true) {
@@ -28,7 +30,13 @@ fun FileBrowserScreen(
         uiEvent.collect { event ->
             when (event) {
                 is FileBrowserUiEvent.ShowSnackbar -> {
-                    snackbarHostState.showSnackbar(event.message)
+                    val result = snackbarHostState.showSnackbar(
+                        message = event.message,
+                        actionLabel = if (event.showAction) "表示" else null,
+                    )
+                    if (result == SnackbarResult.ActionPerformed) {
+                        onNavigateToUploadProgress()
+                    }
                 }
                 is FileBrowserUiEvent.ShowCreateDirectoryDialog -> {
                     showCreateDirectoryDialog.value = true

--- a/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileBrowserUiEvent.kt
+++ b/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileBrowserUiEvent.kt
@@ -1,7 +1,7 @@
 package net.matsudamper.folderviewer.ui.browser
 
 sealed interface FileBrowserUiEvent {
-    data class ShowSnackbar(val message: String) : FileBrowserUiEvent
+    data class ShowSnackbar(val message: String, val showAction: Boolean = false) : FileBrowserUiEvent
     data object ShowCreateDirectoryDialog : FileBrowserUiEvent
     data class ShowDeleteConfirmDialog(val count: Int) : FileBrowserUiEvent
 }

--- a/viewmodel/src/main/java/net/matsudamper/folderviewer/viewmodel/browser/FileBrowserViewModel.kt
+++ b/viewmodel/src/main/java/net/matsudamper/folderviewer/viewmodel/browser/FileBrowserViewModel.kt
@@ -559,7 +559,7 @@ class FileBrowserViewModel @AssistedInject constructor(
         )
 
         WorkManager.getInstance(getApplication()).enqueue(workRequest)
-        uiChannelEvent.send(FileBrowserUiEvent.ShowSnackbar("ファイルのアップロードを開始しました"))
+        uiChannelEvent.send(FileBrowserUiEvent.ShowSnackbar("ファイルのアップロードを開始しました", showAction = true))
     }
 
     private suspend fun handlePaste(clipboardState: ClipboardRepository.ClipboardState) {
@@ -604,7 +604,7 @@ class FileBrowserViewModel @AssistedInject constructor(
             WorkManager.getInstance(getApplication()).enqueue(workRequestWithData)
 
             clipboardRepository.clearClipboard()
-            uiChannelEvent.send(FileBrowserUiEvent.ShowSnackbar("ペーストを開始しました"))
+            uiChannelEvent.send(FileBrowserUiEvent.ShowSnackbar("ペーストを開始しました", showAction = true))
         }.onFailure { e ->
             when (e) {
                 is CancellationException -> throw e
@@ -636,7 +636,7 @@ class FileBrowserViewModel @AssistedInject constructor(
 
             WorkManager.getInstance(getApplication()).enqueue(workRequest)
 
-            uiChannelEvent.send(FileBrowserUiEvent.ShowSnackbar("削除を開始しました"))
+            uiChannelEvent.send(FileBrowserUiEvent.ShowSnackbar("削除を開始しました", showAction = true))
         }.onFailure { e ->
             when (e) {
                 is CancellationException -> throw e
@@ -740,7 +740,7 @@ class FileBrowserViewModel @AssistedInject constructor(
             }
 
             enqueueFolderUpload(documentFile, folderName)
-            uiChannelEvent.send(FileBrowserUiEvent.ShowSnackbar("フォルダのアップロードを開始しました"))
+            uiChannelEvent.send(FileBrowserUiEvent.ShowSnackbar("フォルダのアップロードを開始しました", showAction = true))
         }.onFailure { e ->
             when (e) {
                 is CancellationException -> throw e


### PR DESCRIPTION
- Add showAction field to FileBrowserUiEvent.ShowSnackbar
- Add "表示" (Show) button to snackbar when file/folder upload, paste, or delete starts
- Clicking the button navigates to UploadProgress screen to view operation status
- Update FileBrowserScreen to handle action button callback
- Update MainActivity to provide navigation callback