### PR TITLE
FilePickerActivity: 複数選択送信失敗時のUIフィードバックを追加

### DIFF
--- a/app/src/main/java/net/matsudamper/folderviewer/FilePickerActivity.kt
+++ b/app/src/main/java/net/matsudamper/folderviewer/FilePickerActivity.kt
@@ -221,7 +221,7 @@ private fun ExternalFilePickerEventHandler(
                 }
 
                 ExternalFilePickerViewModel.ViewModelEvent.SubmitFailed -> {
-                    Toast.makeText(context, "ファイルの送信に失敗しました", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(context, "ファイルの取得に失敗しました", Toast.LENGTH_SHORT).show()
                 }
 
                 is ExternalFilePickerViewModel.ViewModelEvent.ReturnMultipleResults -> {

--- a/app/src/main/java/net/matsudamper/folderviewer/FilePickerActivity.kt
+++ b/app/src/main/java/net/matsudamper/folderviewer/FilePickerActivity.kt
@@ -3,6 +3,7 @@ package net.matsudamper.folderviewer
 import android.content.ClipData
 import android.content.Intent
 import android.net.Uri
+import android.widget.Toast
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -217,6 +218,10 @@ private fun ExternalFilePickerEventHandler(
                 is ExternalFilePickerViewModel.ViewModelEvent.ReturnSingleResult -> {
                     val uri = buildUri(context, event.viewSourceUri, event.fileId, event.fileName)
                     onReturnResult(listOf(uri), event.mimeType)
+                }
+
+                ExternalFilePickerViewModel.ViewModelEvent.SubmitFailed -> {
+                    Toast.makeText(context, "ファイルの送信に失敗しました", Toast.LENGTH_SHORT).show()
                 }
 
                 is ExternalFilePickerViewModel.ViewModelEvent.ReturnMultipleResults -> {

--- a/viewmodel/src/main/java/net/matsudamper/folderviewer/viewmodel/picker/ExternalFilePickerViewModel.kt
+++ b/viewmodel/src/main/java/net/matsudamper/folderviewer/viewmodel/picker/ExternalFilePickerViewModel.kt
@@ -121,7 +121,10 @@ class ExternalFilePickerViewModel @AssistedInject constructor(
                         )
                     }
                 }
-                if (results.any { it.isFailure }) return@launch
+                if (results.any { it.isFailure }) {
+                    viewModelEventChannel.send(ViewModelEvent.SubmitFailed)
+                    return@launch
+                }
                 viewModelEventChannel.send(ViewModelEvent.ReturnMultipleResults(results.map { it.getOrThrow() }))
             }
         }
@@ -391,6 +394,7 @@ class ExternalFilePickerViewModel @AssistedInject constructor(
 
     sealed interface ViewModelEvent {
         data object PopBackStack : ViewModelEvent
+        data object SubmitFailed : ViewModelEvent
         data class NavigateToExternalFilePicker(
             val displayPath: String,
             val fileId: FileObjectId.Item,


### PR DESCRIPTION
## Summary
- `ExternalFilePickerViewModel.onSubmit()` でURI解決に失敗した際、サイレントに処理が中断されていた問題を修正
- `ViewModelEvent.SubmitFailed` イベントを追加し、失敗時にToastでユーザーに通知するようにした

## 変更ファイル
- `viewmodel/.../ExternalFilePickerViewModel.kt`: `SubmitFailed`イベント追加、エラー時にemit
- `app/.../FilePickerActivity.kt`: `SubmitFailed`受信時にToast表示

## Test plan
- [ ] 複数ファイルを選択して送信し、正常に結果が返ることを確認
- [ ] ストレージが利用不可の状態で送信し、Toastが表示されることを確認

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ファイル選択機能でアイテム取得に失敗した場合、ユーザーに失敗を通知するトースト表示が追加されました。これにより、エラーが発生した際の操作性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->