### PR TITLE
FilePickerActivity: 呼び出し元のMIMEタイプ制約を反映する

### DIFF
--- a/app/src/main/java/net/matsudamper/folderviewer/FilePickerActivity.kt
+++ b/app/src/main/java/net/matsudamper/folderviewer/FilePickerActivity.kt
@@ -62,6 +62,8 @@ class FilePickerActivity : ComponentActivity() {
         Coil.setImageLoader(imageLoader)
 
         val allowMultiple = intent.getBooleanExtra(Intent.EXTRA_ALLOW_MULTIPLE, false)
+        val acceptedMimeTypes = intent.getStringArrayExtra(Intent.EXTRA_MIME_TYPES)?.toList()
+            ?: listOfNotNull(intent.type)
 
         if (savedInstanceState == null) {
             externalPickerRepository.clear()
@@ -71,6 +73,7 @@ class FilePickerActivity : ComponentActivity() {
             FolderViewerTheme {
                 FilePickerContent(
                     allowMultiple = allowMultiple,
+                    acceptedMimeTypes = acceptedMimeTypes,
                     onReturnResult = { uris, mimeType ->
                         if (uris.isEmpty()) {
                             setResult(RESULT_CANCELED)
@@ -102,6 +105,7 @@ class FilePickerActivity : ComponentActivity() {
 @Composable
 private fun FilePickerContent(
     allowMultiple: Boolean,
+    acceptedMimeTypes: List<String>,
     onReturnResult: (List<Uri>, String?) -> Unit,
     onCancel: () -> Unit,
 ) {
@@ -111,7 +115,7 @@ private fun FilePickerContent(
     )
     val navigator = remember(navigationState) { Navigator(navigationState) }
     val entryProvider = remember(navigator) {
-        entryProvider(navigator, allowMultiple, onReturnResult)
+        entryProvider(navigator, allowMultiple, acceptedMimeTypes, onReturnResult)
     }
 
     NavDisplay(
@@ -133,10 +137,11 @@ private fun FilePickerContent(
 private fun entryProvider(
     navigator: Navigator,
     allowMultiple: Boolean,
+    acceptedMimeTypes: List<String>,
     onReturnResult: (List<Uri>, String?) -> Unit,
 ): (NavKey) -> NavEntry<NavKey> {
     return entryProvider {
-        pickerHomeEntry(navigator, allowMultiple)
+        pickerHomeEntry(navigator, allowMultiple, acceptedMimeTypes)
         externalFilePickerEntry(navigator, onReturnResult)
         externalFilePickerSelectedListEntry(navigator)
         imageViewerEntry(navigator)
@@ -146,6 +151,7 @@ private fun entryProvider(
 private fun EntryProviderScope<NavKey>.pickerHomeEntry(
     navigator: Navigator,
     allowMultiple: Boolean,
+    acceptedMimeTypes: List<String>,
 ) {
     entry<Home> {
         val viewModel: StoragePickerViewModel = hiltViewModel()
@@ -160,6 +166,7 @@ private fun EntryProviderScope<NavKey>.pickerHomeEntry(
                                 allowMultiple = allowMultiple,
                                 displayPath = null,
                                 fileId = FileObjectId.Root(storageId = event.storageId),
+                                acceptedMimeTypes = acceptedMimeTypes,
                             ),
                         )
                     }
@@ -176,6 +183,7 @@ private fun ExternalFilePickerEventHandler(
     viewModel: ExternalFilePickerViewModel,
     navigator: Navigator,
     allowMultiple: Boolean,
+    acceptedMimeTypes: List<String>,
     onReturnResult: (List<Uri>, String?) -> Unit,
 ) {
     val context = LocalContext.current
@@ -191,6 +199,7 @@ private fun ExternalFilePickerEventHandler(
                             allowMultiple = allowMultiple,
                             displayPath = event.displayPath,
                             fileId = event.fileId,
+                            acceptedMimeTypes = acceptedMimeTypes,
                         ),
                     )
                 }
@@ -248,6 +257,7 @@ private fun EntryProviderScope<NavKey>.externalFilePickerEntry(
             viewModel = viewModel,
             navigator = navigator,
             allowMultiple = key.allowMultiple,
+            acceptedMimeTypes = key.acceptedMimeTypes,
             onReturnResult = onReturnResult,
         )
 

--- a/navigation/src/main/java/net/matsudamper/folderviewer/navigation/Destinations.kt
+++ b/navigation/src/main/java/net/matsudamper/folderviewer/navigation/Destinations.kt
@@ -49,6 +49,7 @@ data class ExternalFilePicker(
     val allowMultiple: Boolean,
     val displayPath: String?,
     val fileId: FileObjectId,
+    val acceptedMimeTypes: List<String> = emptyList(),
 ) : NavKey
 
 @Serializable

--- a/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileBrowserUiState.kt
+++ b/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileBrowserUiState.kt
@@ -40,6 +40,7 @@ data class FileBrowserUiState(
             val subText: String,
             val thumbnail: FileImageSource.Thumbnail?,
             val isSelected: Boolean,
+            val isEnabled: Boolean = true,
             val callbacks: Callbacks,
         ) : UiFileItem {
             @Immutable

--- a/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileListItem.kt
+++ b/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileListItem.kt
@@ -40,14 +40,15 @@ private fun DisabledContentProvider(
     isEnabled: Boolean,
     content: @Composable () -> Unit,
 ) {
-    if (isEnabled) {
-        content()
+    val contentColor = if (isEnabled) {
+        LocalContentColor.current
     } else {
-        CompositionLocalProvider(
-            LocalContentColor provides LocalContentColor.current.copy(alpha = 0.38f),
-            content = content,
-        )
+        LocalContentColor.current.copy(alpha = 0.38f)
     }
+    CompositionLocalProvider(
+        LocalContentColor provides contentColor,
+        content = content,
+    )
 }
 
 @Composable

--- a/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileListItem.kt
+++ b/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileListItem.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -27,13 +28,27 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImagePainter
 import coil.compose.SubcomposeAsyncImage
 import coil.compose.SubcomposeAsyncImageContent
 import net.matsudamper.folderviewer.ui.R
+
+@Composable
+private fun DisabledContentProvider(
+    isEnabled: Boolean,
+    content: @Composable () -> Unit,
+) {
+    if (isEnabled) {
+        content()
+    } else {
+        CompositionLocalProvider(
+            LocalContentColor provides LocalContentColor.current.copy(alpha = 0.38f),
+            content = content,
+        )
+    }
+}
 
 @Composable
 internal fun FileHeaderItem(
@@ -63,39 +78,40 @@ internal fun FileSmallListItem(
     isPasteMode: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .combinedClickable(
-                enabled = file.isEnabled,
-                onClick = file.callbacks::onClick,
-                onLongClick = if (isPasteMode) null else file.callbacks::onLongClick,
+    DisabledContentProvider(file.isEnabled) {
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .combinedClickable(
+                    enabled = file.isEnabled,
+                    onClick = file.callbacks::onClick,
+                    onLongClick = if (isPasteMode) null else file.callbacks::onLongClick,
+                )
+                .padding(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (isSelectionMode) {
+                Checkbox(
+                    checked = file.isSelected,
+                    enabled = file.isEnabled,
+                    onCheckedChange = file.callbacks::onCheckedChange,
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+            }
+            FileIcon(
+                file = file,
+                modifier = Modifier
+                    .size(24.dp)
+                    .aspectRatio(1f)
+                    .clip(MaterialTheme.shapes.extraSmall),
             )
-            .alpha(if (file.isEnabled) 1f else 0.38f)
-            .padding(8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        if (isSelectionMode) {
-            Checkbox(
-                checked = file.isSelected,
-                enabled = file.isEnabled,
-                onCheckedChange = file.callbacks::onCheckedChange,
+            Spacer(modifier = Modifier.width(8.dp))
+            FileNameText(
+                name = file.name,
+                textOverflow = textOverflow,
+                maxLines = 1,
             )
-            Spacer(modifier = Modifier.width(4.dp))
         }
-        FileIcon(
-            file = file,
-            modifier = Modifier
-                .size(24.dp)
-                .aspectRatio(1f)
-                .clip(MaterialTheme.shapes.extraSmall),
-        )
-        Spacer(modifier = Modifier.width(8.dp))
-        FileNameText(
-            name = file.name,
-            textOverflow = textOverflow,
-            maxLines = 1,
-        )
     }
 }
 
@@ -108,46 +124,47 @@ internal fun FileMediumListItem(
     isPasteMode: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .combinedClickable(
-                enabled = file.isEnabled,
-                onClick = file.callbacks::onClick,
-                onLongClick = if (isPasteMode) null else file.callbacks::onLongClick,
+    DisabledContentProvider(file.isEnabled) {
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .combinedClickable(
+                    enabled = file.isEnabled,
+                    onClick = file.callbacks::onClick,
+                    onLongClick = if (isPasteMode) null else file.callbacks::onLongClick,
+                )
+                .padding(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (isSelectionMode) {
+                Checkbox(
+                    checked = file.isSelected,
+                    enabled = file.isEnabled,
+                    onCheckedChange = file.callbacks::onCheckedChange,
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+            }
+            FileIcon(
+                file = file,
+                modifier = Modifier
+                    .size(50.dp)
+                    .aspectRatio(1f)
+                    .clip(MaterialTheme.shapes.extraSmall),
             )
-            .alpha(if (file.isEnabled) 1f else 0.38f)
-            .padding(4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        if (isSelectionMode) {
-            Checkbox(
-                checked = file.isSelected,
-                enabled = file.isEnabled,
-                onCheckedChange = file.callbacks::onCheckedChange,
-            )
-            Spacer(modifier = Modifier.width(4.dp))
-        }
-        FileIcon(
-            file = file,
-            modifier = Modifier
-                .size(50.dp)
-                .aspectRatio(1f)
-                .clip(MaterialTheme.shapes.extraSmall),
-        )
-        Spacer(modifier = Modifier.width(8.dp))
-        Column {
-            FileNameText(
-                name = file.name,
-                maxLines = 2,
-                textOverflow = textOverflow,
-            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Column {
+                FileNameText(
+                    name = file.name,
+                    maxLines = 2,
+                    textOverflow = textOverflow,
+                )
 
-            Text(
-                text = file.subText,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+                Text(
+                    text = file.subText,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
     }
 }
@@ -161,46 +178,47 @@ internal fun FileLargeListItem(
     isPasteMode: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .combinedClickable(
-                enabled = file.isEnabled,
-                onClick = file.callbacks::onClick,
-                onLongClick = if (isPasteMode) null else file.callbacks::onLongClick,
+    DisabledContentProvider(file.isEnabled) {
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .combinedClickable(
+                    enabled = file.isEnabled,
+                    onClick = file.callbacks::onClick,
+                    onLongClick = if (isPasteMode) null else file.callbacks::onLongClick,
+                )
+                .padding(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (isSelectionMode) {
+                Checkbox(
+                    checked = file.isSelected,
+                    enabled = file.isEnabled,
+                    onCheckedChange = file.callbacks::onCheckedChange,
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+            }
+            FileIcon(
+                file = file,
+                modifier = Modifier
+                    .size(100.dp)
+                    .aspectRatio(1f)
+                    .clip(MaterialTheme.shapes.medium),
             )
-            .alpha(if (file.isEnabled) 1f else 0.38f)
-            .padding(4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        if (isSelectionMode) {
-            Checkbox(
-                checked = file.isSelected,
-                enabled = file.isEnabled,
-                onCheckedChange = file.callbacks::onCheckedChange,
-            )
-            Spacer(modifier = Modifier.width(4.dp))
-        }
-        FileIcon(
-            file = file,
-            modifier = Modifier
-                .size(100.dp)
-                .aspectRatio(1f)
-                .clip(MaterialTheme.shapes.medium),
-        )
-        Spacer(modifier = Modifier.width(8.dp))
-        Column {
-            FileNameText(
-                name = file.name,
-                maxLines = 4,
-                textOverflow = textOverflow,
-            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Column {
+                FileNameText(
+                    name = file.name,
+                    maxLines = 4,
+                    textOverflow = textOverflow,
+                )
 
-            Text(
-                text = file.subText,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+                Text(
+                    text = file.subText,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
     }
 }
@@ -267,43 +285,44 @@ private fun FileGridItem(
     isPasteMode: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier
-            .combinedClickable(
-                enabled = file.isEnabled,
-                onClick = file.callbacks::onClick,
-                onLongClick = if (isPasteMode) null else file.callbacks::onLongClick,
-            )
-            .alpha(if (file.isEnabled) 1f else 0.38f)
-            .padding(padding),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Box {
-            FileIcon(
-                file = file,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(1f)
-                    .clip(MaterialTheme.shapes.medium)
-                    .background(MaterialTheme.colorScheme.surfaceVariant),
-            )
-            if (isSelectionMode) {
-                Checkbox(
-                    checked = file.isSelected,
+    DisabledContentProvider(file.isEnabled) {
+        Column(
+            modifier = modifier
+                .combinedClickable(
                     enabled = file.isEnabled,
-                    onCheckedChange = file.callbacks::onCheckedChange,
-                    modifier = Modifier.align(Alignment.TopStart),
+                    onClick = file.callbacks::onClick,
+                    onLongClick = if (isPasteMode) null else file.callbacks::onLongClick,
                 )
+                .padding(padding),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Box {
+                FileIcon(
+                    file = file,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(1f)
+                        .clip(MaterialTheme.shapes.medium)
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                )
+                if (isSelectionMode) {
+                    Checkbox(
+                        checked = file.isSelected,
+                        enabled = file.isEnabled,
+                        onCheckedChange = file.callbacks::onCheckedChange,
+                        modifier = Modifier.align(Alignment.TopStart),
+                    )
+                }
             }
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = file.name,
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 2,
+                overflow = textOverflow,
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+            )
         }
-        Spacer(modifier = Modifier.height(4.dp))
-        Text(
-            text = file.name,
-            style = MaterialTheme.typography.bodyMedium,
-            maxLines = 2,
-            overflow = textOverflow,
-            textAlign = androidx.compose.ui.text.style.TextAlign.Center,
-        )
     }
 }
 

--- a/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileListItem.kt
+++ b/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileListItem.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImagePainter
@@ -66,15 +67,18 @@ internal fun FileSmallListItem(
         modifier = modifier
             .fillMaxWidth()
             .combinedClickable(
+                enabled = file.isEnabled,
                 onClick = file.callbacks::onClick,
                 onLongClick = if (isPasteMode) null else file.callbacks::onLongClick,
             )
+            .alpha(if (file.isEnabled) 1f else 0.38f)
             .padding(8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (isSelectionMode) {
             Checkbox(
                 checked = file.isSelected,
+                enabled = file.isEnabled,
                 onCheckedChange = file.callbacks::onCheckedChange,
             )
             Spacer(modifier = Modifier.width(4.dp))
@@ -108,15 +112,18 @@ internal fun FileMediumListItem(
         modifier = modifier
             .fillMaxWidth()
             .combinedClickable(
+                enabled = file.isEnabled,
                 onClick = file.callbacks::onClick,
                 onLongClick = if (isPasteMode) null else file.callbacks::onLongClick,
             )
+            .alpha(if (file.isEnabled) 1f else 0.38f)
             .padding(4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (isSelectionMode) {
             Checkbox(
                 checked = file.isSelected,
+                enabled = file.isEnabled,
                 onCheckedChange = file.callbacks::onCheckedChange,
             )
             Spacer(modifier = Modifier.width(4.dp))
@@ -158,15 +165,18 @@ internal fun FileLargeListItem(
         modifier = modifier
             .fillMaxWidth()
             .combinedClickable(
+                enabled = file.isEnabled,
                 onClick = file.callbacks::onClick,
                 onLongClick = if (isPasteMode) null else file.callbacks::onLongClick,
             )
+            .alpha(if (file.isEnabled) 1f else 0.38f)
             .padding(4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (isSelectionMode) {
             Checkbox(
                 checked = file.isSelected,
+                enabled = file.isEnabled,
                 onCheckedChange = file.callbacks::onCheckedChange,
             )
             Spacer(modifier = Modifier.width(4.dp))
@@ -260,9 +270,11 @@ private fun FileGridItem(
     Column(
         modifier = modifier
             .combinedClickable(
+                enabled = file.isEnabled,
                 onClick = file.callbacks::onClick,
                 onLongClick = if (isPasteMode) null else file.callbacks::onLongClick,
             )
+            .alpha(if (file.isEnabled) 1f else 0.38f)
             .padding(padding),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
@@ -278,6 +290,7 @@ private fun FileGridItem(
             if (isSelectionMode) {
                 Checkbox(
                     checked = file.isSelected,
+                    enabled = file.isEnabled,
                     onCheckedChange = file.callbacks::onCheckedChange,
                     modifier = Modifier.align(Alignment.TopStart),
                 )

--- a/viewmodel/src/main/java/net/matsudamper/folderviewer/viewmodel/picker/ExternalFilePickerViewModel.kt
+++ b/viewmodel/src/main/java/net/matsudamper/folderviewer/viewmodel/picker/ExternalFilePickerViewModel.kt
@@ -135,6 +135,8 @@ class ExternalFilePickerViewModel @AssistedInject constructor(
 
         val uiItems = sortedFiles.map { fileItem ->
             val isImage = FileUtil.isImage(fileItem.displayPath)
+            val isEnabled = fileItem.isDirectory ||
+                FileUtil.matchesMimeFilter(fileItem.displayPath, arg.acceptedMimeTypes)
             FileBrowserUiState.UiFileItem.File(
                 name = fileItem.displayPath,
                 key = fileItem.id.id,
@@ -142,6 +144,7 @@ class ExternalFilePickerViewModel @AssistedInject constructor(
                 subText = buildSubText(fileItem.isDirectory, fileItem.lastModified, fileItem.size),
                 thumbnail = if (isImage) FileImageSource.Thumbnail(fileId = fileItem.id) else null,
                 isSelected = selectedItems.containsKey(fileItem.id),
+                isEnabled = isEnabled,
                 callbacks = FileItemCallbacks(fileItem, sortedFiles),
             )
         }

--- a/viewmodel/src/main/java/net/matsudamper/folderviewer/viewmodel/util/FileUtil.kt
+++ b/viewmodel/src/main/java/net/matsudamper/folderviewer/viewmodel/util/FileUtil.kt
@@ -24,4 +24,17 @@ object FileUtil {
         if (extension.isEmpty()) return null
         return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension.lowercase())
     }
+
+    fun matchesMimeFilter(fileName: String, acceptedMimeTypes: List<String>): Boolean {
+        if (acceptedMimeTypes.isEmpty()) return true
+        if (acceptedMimeTypes.any { it == "*/*" }) return true
+        val fileMimeType = getMimeType(fileName) ?: return false
+        return acceptedMimeTypes.any { pattern ->
+            if (pattern.endsWith("/*")) {
+                fileMimeType.startsWith(pattern.substringBefore("/*") + "/")
+            } else {
+                fileMimeType.equals(pattern, ignoreCase = true)
+            }
+        }
+    }
 }

--- a/viewmodel/src/main/java/net/matsudamper/folderviewer/viewmodel/util/FileUtil.kt
+++ b/viewmodel/src/main/java/net/matsudamper/folderviewer/viewmodel/util/FileUtil.kt
@@ -28,7 +28,7 @@ object FileUtil {
     fun matchesMimeFilter(fileName: String, acceptedMimeTypes: List<String>): Boolean {
         if (acceptedMimeTypes.isEmpty()) return true
         if (acceptedMimeTypes.any { it == "*/*" }) return true
-        val fileMimeType = getMimeType(fileName) ?: return false
+        val fileMimeType = getMimeType(fileName) ?: return true
         return acceptedMimeTypes.any { pattern ->
             if (pattern.endsWith("/*")) {
                 fileMimeType.startsWith(pattern.substringBefore("/*") + "/")


### PR DESCRIPTION
## Summary
- `FilePickerActivity`で`intent.type`と`EXTRA_MIME_TYPES`を読み取り、MIMEタイプ制約をナビゲーション経由でViewModelに伝播
- MIMEタイプが一致しないファイルをグレーアウト表示（alpha 0.38）し、クリック・チェックボックスを無効化
- ディレクトリは常に表示・クリック可能
- ワイルドカード（`image/*`、`*/*`）に対応

Closes #165

## Test plan
- [ ] `ACTION_GET_CONTENT`で`type=image/*`を指定してFilePickerを起動し、画像以外のファイルがグレーアウトされることを確認
- [ ] グレーアウトされたファイルがクリック不可であることを確認
- [ ] ディレクトリは常にクリック可能であることを確認
- [ ] `EXTRA_MIME_TYPES`で複数MIMEタイプを指定した場合に正しくフィルタリングされることを確認
- [ ] MIMEタイプ制約なし（通常起動）の場合、全ファイルが有効であることを確認
- [ ] 複数選択モードでもグレーアウト・チェックボックス無効が正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)