### PR TITLE
直前に開いたファイルの背景を薄くハイライト表示する

### DIFF
--- a/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileBrowserUiState.kt
+++ b/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileBrowserUiState.kt
@@ -40,6 +40,7 @@ data class FileBrowserUiState(
             val subText: String,
             val thumbnail: FileImageSource.Thumbnail?,
             val isSelected: Boolean,
+            val isLastOpened: Boolean = false,
             val isEnabled: Boolean = true,
             val callbacks: Callbacks,
         ) : UiFileItem {

--- a/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileListItem.kt
+++ b/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileListItem.kt
@@ -83,6 +83,13 @@ internal fun FileSmallListItem(
         Row(
             modifier = modifier
                 .fillMaxWidth()
+                .then(
+                    if (file.isLastOpened) {
+                        Modifier.background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f))
+                    } else {
+                        Modifier
+                    },
+                )
                 .combinedClickable(
                     enabled = file.isEnabled,
                     onClick = file.callbacks::onClick,
@@ -129,6 +136,13 @@ internal fun FileMediumListItem(
         Row(
             modifier = modifier
                 .fillMaxWidth()
+                .then(
+                    if (file.isLastOpened) {
+                        Modifier.background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f))
+                    } else {
+                        Modifier
+                    },
+                )
                 .combinedClickable(
                     enabled = file.isEnabled,
                     onClick = file.callbacks::onClick,
@@ -183,6 +197,13 @@ internal fun FileLargeListItem(
         Row(
             modifier = modifier
                 .fillMaxWidth()
+                .then(
+                    if (file.isLastOpened) {
+                        Modifier.background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f))
+                    } else {
+                        Modifier
+                    },
+                )
                 .combinedClickable(
                     enabled = file.isEnabled,
                     onClick = file.callbacks::onClick,
@@ -289,6 +310,13 @@ private fun FileGridItem(
     DisabledContentProvider(file.isEnabled) {
         Column(
             modifier = modifier
+                .then(
+                    if (file.isLastOpened) {
+                        Modifier.background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f))
+                    } else {
+                        Modifier
+                    },
+                )
                 .combinedClickable(
                     enabled = file.isEnabled,
                     onClick = file.callbacks::onClick,

--- a/viewmodel/src/main/java/net/matsudamper/folderviewer/viewmodel/browser/FileBrowserViewModel.kt
+++ b/viewmodel/src/main/java/net/matsudamper/folderviewer/viewmodel/browser/FileBrowserViewModel.kt
@@ -360,6 +360,7 @@ class FileBrowserViewModel @AssistedInject constructor(
                     null
                 },
                 isSelected = selectedItems.contains(fileItem.id),
+                isLastOpened = fileItem.id.id == viewModelState.lastOpenedFileKey,
                 callbacks = FileItemCallbacks(fileItem, sortedFiles, isSelectionMode),
             )
         }
@@ -912,6 +913,8 @@ class FileBrowserViewModel @AssistedInject constructor(
                 val isImage = FileUtil.isImage(fileItem.displayPath.lowercase())
                 val isVideo = FileUtil.isVideo(fileItem.displayPath.lowercase())
 
+                viewModelStateFlow.update { it.copy(lastOpenedFileKey = fileItem.id.id) }
+
                 when {
                     isImage -> {
                         viewModelScope.launch {
@@ -1050,6 +1053,7 @@ class FileBrowserViewModel @AssistedInject constructor(
         val selectedState: SelectionState = SelectionState.NonSelected,
         val rootWritable: Boolean = false,
         val localFolderPath: String? = null,
+        val lastOpenedFileKey: String? = null,
     ) {
         sealed interface SelectionState {
             data object NonSelected : SelectionState


### PR DESCRIPTION
外部アプリまたはアプリ内画像ビューアでファイルを開いて元の画面に戻ったとき、
直前に選択したファイルの背景に薄い色を表示して識別しやすくする。

- FileBrowserUiState.UiFileItem.File に isLastOpened フラグを追加
- ViewModelState に lastOpenedFileKey を追加し、ファイルオープン時に記録
- リスト/グリッド各アイテムに primary カラー 12% 透過の背景を適用

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 最後に開いたファイルを視覚的に強調表示する機能を追加。すべてのビュー形式（リスト表示、グリッド表示）で統一された背景色により、直近で開いたファイルを一目で識別できるようになりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matsudamper/FolderViewer/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->