### PR TITLE
CI/CDワークフローを簡略化し、APKアップロード完了通知に変更

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      id-token: write
     env:
       DEBUG_KEYSTORE_FILE: debug.keystore
 
@@ -37,72 +36,21 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew assembleDebug ktlintCheck detekt
 
-      - name: Rename APK with branch and short hash
-        if: github.event_name == 'pull_request'
-        env:
-          BRANCH_NAME: ${{ github.head_ref }}
-          REPOSITORY: ${{ github.repository }}
-        run: |
-          SHORT_SHA="${GITHUB_SHA:0:7}"
-          SAFE_REPO="${REPOSITORY##*/}"
-          SAFE_BRANCH="${BRANCH_NAME//\//-}"
-          APK_NAME="app-${SAFE_REPO}-${SAFE_BRANCH}-${SHORT_SHA}.apk"
-          APK_SRC=$(find app/build/outputs/apk/debug -name "*.apk" | head -1)
-          mv "$APK_SRC" "app/build/outputs/apk/debug/${APK_NAME}"
-          echo "APK_NAME=${APK_NAME}" >> "$GITHUB_ENV"
-
       - name: Upload APK
         id: upload_apk
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ env.APK_NAME || 'debug-apk' }}
+          name: apk
           path: app/build/outputs/apk/debug/*.apk
 
-      - name: Upload APK to S3
+      - name: APKアップロード完了コメント
         if: github.event_name == 'pull_request'
-        id: upload_s3
-        uses: matsudamper/actions/upload-matsudamper-s3@a1ecf81b1a0ce320824a49711e456f396e4e8fea
-        continue-on-error: true
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
-          file_path: app/build/outputs/apk/debug/${{ env.APK_NAME }}
-
-      - name: Generate and upload GitHub QR code
-        if: github.event_name == 'pull_request'
-        id: upload_github_qr
-        run: |
-          pip install "qrcode[pil]" --quiet
-          python3 -c "import qrcode, sys; qrcode.make(sys.argv[1]).save('qrcode-github.png')" "${{ steps.upload_apk.outputs.artifact-url }}"
-
-      - name: Upload GitHub QR artifact
-        if: github.event_name == 'pull_request'
-        id: github_qr_artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: apk-qr-code-github
-          path: qrcode-github.png
-
-      - name: Generate S3 QR code
-        if: github.event_name == 'pull_request' && steps.upload_s3.outputs.url != ''
-        run: python3 -c "import qrcode, sys; qrcode.make(sys.argv[1]).save('qrcode-s3.png')" "${{ steps.upload_s3.outputs.url }}"
-
-      - name: Upload S3 QR artifact
-        if: github.event_name == 'pull_request' && steps.upload_s3.outputs.url != ''
-        id: s3_qr_artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: apk-qr-code-s3
-          path: qrcode-s3.png
-
-      - name: Comment APK download URLs
-        if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: apk-download
+          header: apk-upload
           message: |
-            ✅ **Debug APK is ready!**
-            | Storage | Download Link | QR Code |
-            | :--- | :--- | :--- |
-            | 🐙 GitHub Artifacts | [Download](${{ steps.upload_apk.outputs.artifact-url }}) | [View](${{ steps.github_qr_artifact.outputs.artifact-url }}) |
-            ${{ steps.upload_s3.outputs.url && format('| ☁️ S3 | [Download]({0}) | [View]({1}) |', steps.upload_s3.outputs.url, steps.s3_qr_artifact.outputs.artifact-url) || '' }}
-            ---
-            *Artifact Name: `${{ env.APK_NAME }}`*
+            ✅ APKのアップロードが完了しました。
+
+            - Artifact名: `apk`
+            - APKダウンロード: ${{ steps.upload_apk.outputs.artifact-url }}
+            - Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
## 概要
GitHub Actionsのビルドワークフローをシンプルに簡略化し、APKアップロード後の通知方法を変更しました。

## 主な変更
- **権限設定の削除**: `id-token: write`権限を削除
- **APK命名ロジックの削除**: ブランチ名とコミットハッシュを含むAPK命名処理を廃止し、シンプルな`apk`という固定名に統一
- **S3アップロード機能の削除**: S3へのアップロード処理とそれに関連するQRコード生成機能を完全に削除
- **QRコード生成機能の削除**: GitHub ArtifactsおよびS3用のQRコード生成・アップロード処理を削除
- **PR通知の簡略化**: 複雑なテーブル形式の通知から、シンプルなテキスト形式の通知に変更
  - 通知ヘッダーを`apk-download`から`apk-upload`に変更
  - GitHub Artifactのダウンロードリンク、実行ページへのリンクのみを表示
  - sticky-pull-request-commentのバージョンをv2からv3に更新

## 実装の詳細
ワークフローの複雑性を大幅に削減し、メンテナンスコストを低下させました。APKのアップロード完了を簡潔に通知するシンプルな構成になっています。

https://claude.ai/code/session_012AoWNdm4GEHMQdTh6CXVWn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * GitHub Actions のワークフロー処理を簡素化しました。APK アーティファクトのアップロード完了通知が日本語のコメントで表示されるようになります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matsudamper/FolderViewer/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->