### PR TITLE
サムネイル画像の圧縮品質を80から75に変更

### DIFF
--- a/repository/src/main/java/net/matsudamper/folderviewer/repository/LocalFileRepository.kt
+++ b/repository/src/main/java/net/matsudamper/folderviewer/repository/LocalFileRepository.kt
@@ -120,7 +120,7 @@ internal class LocalFileRepository(
                         ?: return@withContext getFileContent(fileId)
 
                     val bos = ByteArrayOutputStream()
-                    bitmap.compress(Bitmap.CompressFormat.JPEG, 80, bos)
+                    bitmap.compress(Bitmap.CompressFormat.JPEG, 75, bos)
                     bitmap.recycle()
 
                     ByteArrayInputStream(bos.toByteArray())

--- a/repository/src/main/java/net/matsudamper/folderviewer/repository/SmbFileRepository.kt
+++ b/repository/src/main/java/net/matsudamper/folderviewer/repository/SmbFileRepository.kt
@@ -262,7 +262,7 @@ class SmbFileRepository(
                 } ?: return@withContext getFileContentInternal(fileId.id, maxReadSize = MAX_THUMBNAIL_READ_SIZE.toLong())
 
                 val bos = ByteArrayOutputStream()
-                bitmap.compress(Bitmap.CompressFormat.JPEG, 80, bos)
+                bitmap.compress(Bitmap.CompressFormat.JPEG, 75, bos)
                 bitmap.recycle()
 
                 ByteArrayInputStream(bos.toByteArray())


### PR DESCRIPTION
## 概要
ローカルファイルとSMBファイルのサムネイル生成時に使用するJPEG圧縮品質を80から75に変更しました。

## 変更内容
- `LocalFileRepository.kt`: ビットマップ圧縮時の品質パラメータを80から75に変更
- `SmbFileRepository.kt`: ビットマップ圧縮時の品質パラメータを80から75に変更

## 実装の詳細
両リポジトリのサムネイル生成処理において、`Bitmap.compress()`メソッドに渡す品質値を調整しました。これにより、サムネイル画像のファイルサイズをさらに削減しながら、視覚的な品質を維持します。

https://claude.ai/code/session_01LyHUP9HtTGdsDmf1YYyqCy