### PR TITLE
テスト失敗時のログ出力を詳細化

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,15 @@ subprojects {
             md.required.set(false)
         }
     }
+    tasks.withType<Test> {
+        testLogging {
+            events("failed")
+            exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+            showCauses = true
+            showExceptions = true
+            showStackTraces = true
+        }
+    }
     tasks.withType<KotlinJvmCompile> {
         compilerOptions {
             allWarningsAsErrors.set(true)


### PR DESCRIPTION
## 概要
テスト実行時の失敗ログをより詳細に出力するよう、Gradle設定を改善しました。

## 変更内容
- `build.gradle.kts`に`Test`タスクのログ設定を追加
  - 失敗したテストのみをイベント出力対象に指定
  - 例外フォーマットを`FULL`に設定して完全な情報を表示
  - 原因、例外、スタックトレースの表示を有効化

## 実装の詳細
テスト失敗時に以下の情報が詳細に出力されるようになります：
- 例外の完全なスタックトレース
- 例外の原因チェーン
- 例外メッセージ

これにより、テスト失敗時のデバッグが容易になります。

https://claude.ai/code/session_01MzdDCvtKVANbBPGy25X8QX