### PR TITLE
外部ストレージ（SDカード等）のサポートを追加

### DIFF
--- a/repository/src/main/java/net/matsudamper/folderviewer/repository/ExternalStorageRepository.kt
+++ b/repository/src/main/java/net/matsudamper/folderviewer/repository/ExternalStorageRepository.kt
@@ -1,0 +1,69 @@
+package net.matsudamper.folderviewer.repository
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Environment
+import android.os.storage.StorageManager
+import androidx.core.content.ContextCompat
+import dagger.hilt.android.qualifiers.ApplicationContext
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import net.matsudamper.folderviewer.common.StorageId
+
+@Singleton
+class ExternalStorageRepository @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+) {
+    val externalStorages: Flow<List<StorageConfiguration.External>> = callbackFlow {
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                trySend(loadExternalStorages())
+            }
+        }
+        val filter = IntentFilter().apply {
+            addAction(Intent.ACTION_MEDIA_MOUNTED)
+            addAction(Intent.ACTION_MEDIA_UNMOUNTED)
+            addAction(Intent.ACTION_MEDIA_EJECT)
+            addAction(Intent.ACTION_MEDIA_REMOVED)
+            addAction(Intent.ACTION_MEDIA_BAD_REMOVAL)
+            addDataScheme("file")
+        }
+        ContextCompat.registerReceiver(context, receiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
+        trySend(loadExternalStorages())
+        awaitClose { context.unregisterReceiver(receiver) }
+    }.distinctUntilChanged()
+
+    fun findExternalStorage(id: StorageId): StorageConfiguration.External? {
+        return loadExternalStorages().find { it.id == id }
+    }
+
+    private fun loadExternalStorages(): List<StorageConfiguration.External> {
+        val storageManager = context.getSystemService(StorageManager::class.java)
+            ?: return emptyList()
+        return context.getExternalFilesDirs(null)
+            .filterNotNull()
+            .mapNotNull { filesDir ->
+                val volume = storageManager.getStorageVolume(filesDir) ?: return@mapNotNull null
+                if (!volume.isRemovable) return@mapNotNull null
+                if (volume.state != Environment.MEDIA_MOUNTED) return@mapNotNull null
+                val uuid = volume.uuid ?: return@mapNotNull null
+                StorageConfiguration.External(
+                    id = StorageId("$ExternalStorageIdPrefix$uuid"),
+                    name = volume.getDescription(context) ?: DefaultExternalStorageName,
+                    rootPath = filesDir.absolutePath.substringBefore("/Android/"),
+                )
+            }
+            .distinctBy { it.id }
+    }
+
+    companion object {
+        private const val ExternalStorageIdPrefix = "external:"
+        private const val DefaultExternalStorageName = "外部ストレージ"
+    }
+}

--- a/repository/src/main/java/net/matsudamper/folderviewer/repository/StorageConfiguration.kt
+++ b/repository/src/main/java/net/matsudamper/folderviewer/repository/StorageConfiguration.kt
@@ -25,6 +25,13 @@ sealed interface StorageConfiguration {
     ) : StorageConfiguration
 
     @Serializable
+    data class External(
+        override val id: StorageId,
+        override val name: String,
+        val rootPath: String,
+    ) : StorageConfiguration
+
+    @Serializable
     data class SharePoint(
         override val id: StorageId,
         override val name: String,

--- a/repository/src/main/java/net/matsudamper/folderviewer/repository/StorageRepository.kt
+++ b/repository/src/main/java/net/matsudamper/folderviewer/repository/StorageRepository.kt
@@ -9,6 +9,7 @@ import jakarta.inject.Inject
 import jakarta.inject.Singleton
 import java.util.UUID
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import net.matsudamper.folderviewer.common.FileObjectId
@@ -31,11 +32,16 @@ private val Context.dataStore: DataStore<StorageListProto> by dataStore(
 @Singleton
 class StorageRepository @Inject constructor(
     @param:ApplicationContext private val context: Context,
+    private val externalStorageRepository: ExternalStorageRepository,
 ) {
-    val storageList: Flow<List<StorageConfiguration>> =
+    val storageList: Flow<List<StorageConfiguration>> = combine(
         context.dataStore.data.map { storageProto ->
             storageProto.listList.mapNotNull { it.toDomain() }
-        }
+        },
+        externalStorageRepository.externalStorages,
+    ) { storages, externalStorages ->
+        storages + externalStorages
+    }
 
     val favorites: Flow<List<FavoriteConfiguration>> = context.dataStore.data
         .map { proto ->
@@ -205,26 +211,42 @@ class StorageRepository @Inject constructor(
 
     suspend fun isRootWritable(fileObjectId: FileObjectId): Boolean {
         if (fileObjectId is FileObjectId.Item) return true
+        if (externalStorageRepository.findExternalStorage(fileObjectId.storageId) != null) return true
         val proto = context.dataStore.data.first()
         val configProto = proto.listList.find { it.id == fileObjectId.storageId.id } ?: return false
         return when (configProto.toDomain()) {
             is StorageConfiguration.Smb -> false
             is StorageConfiguration.Local -> true
+            is StorageConfiguration.External -> true
             is StorageConfiguration.SharePoint -> true
             null -> false
         }
     }
 
     suspend fun getFileRepository(id: StorageId): FileRepository? {
+        val externalStorage = externalStorageRepository.findExternalStorage(id)
+        if (externalStorage != null) {
+            return LocalFileRepository(externalStorage.toLocalConfiguration(), context)
+        }
+
         val proto = context.dataStore.data.first()
         val configProto = proto.listList.find { it.id == id.id } ?: return null
 
         return when (val config = configProto.toDomain()) {
             is StorageConfiguration.Smb -> SmbFileRepository(config)
             is StorageConfiguration.Local -> LocalFileRepository(config, context)
+            is StorageConfiguration.External -> LocalFileRepository(config.toLocalConfiguration(), context)
             is StorageConfiguration.SharePoint -> SharePointFileRepository(config)
             null -> null
         }
+    }
+
+    private fun StorageConfiguration.External.toLocalConfiguration(): StorageConfiguration.Local {
+        return StorageConfiguration.Local(
+            id = id,
+            name = name,
+            rootPath = rootPath,
+        )
     }
 
     private fun StorageConfigurationProto.toDomain(): StorageConfiguration? {

--- a/ui/src/main/java/net/matsudamper/folderviewer/ui/home/HomeScreenPreview.kt
+++ b/ui/src/main/java/net/matsudamper/folderviewer/ui/home/HomeScreenPreview.kt
@@ -16,6 +16,11 @@ private fun HomeScreenPreview() {
                     ip = "192.168.1.10",
                     username = "user",
                 ),
+                UiStorageConfiguration.External(
+                    id = StorageId("external:1234-ABCD"),
+                    name = "USBドライブ",
+                    rootPath = "/storage/1234-ABCD",
+                ),
             ),
             callbacks = object : HomeUiState.Callbacks {
                 override fun onNavigateToSettings() = Unit

--- a/ui/src/main/java/net/matsudamper/folderviewer/ui/home/StorageItem.kt
+++ b/ui/src/main/java/net/matsudamper/folderviewer/ui/home/StorageItem.kt
@@ -35,7 +35,11 @@ internal fun StorageItem(
             .fillMaxWidth()
             .combinedClickable(
                 onClick = onClick,
-                onLongClick = { showMenu = true },
+                onLongClick = if (storage is UiStorageConfiguration.External) {
+                    null
+                } else {
+                    { showMenu = true }
+                },
             ),
     ) {
         Box {
@@ -79,6 +83,7 @@ internal fun StorageItemContent(
         val type = when (storage) {
             is UiStorageConfiguration.Smb -> "SMB: ${storage.ip}"
             is UiStorageConfiguration.Local -> "ローカル: ${storage.rootPath}"
+            is UiStorageConfiguration.External -> "外部ストレージ: ${storage.rootPath}"
             is UiStorageConfiguration.SharePoint -> storage.objectId
         }
         Text(text = type, style = MaterialTheme.typography.bodyMedium)
@@ -126,6 +131,8 @@ private fun StorageItemMenu(
                     onClick = onDeleteClick,
                 )
             }
+
+            is UiStorageConfiguration.External -> Unit
         }
     }
 }

--- a/ui/src/main/java/net/matsudamper/folderviewer/ui/home/UiStorageConfiguration.kt
+++ b/ui/src/main/java/net/matsudamper/folderviewer/ui/home/UiStorageConfiguration.kt
@@ -19,6 +19,12 @@ public sealed interface UiStorageConfiguration {
         val rootPath: String,
     ) : UiStorageConfiguration
 
+    public data class External(
+        override val id: StorageId,
+        override val name: String,
+        val rootPath: String,
+    ) : UiStorageConfiguration
+
     public data class SharePoint(
         override val id: StorageId,
         override val name: String,

--- a/viewmodel/src/main/java/net/matsudamper/folderviewer/viewmodel/browser/FileBrowserViewModel.kt
+++ b/viewmodel/src/main/java/net/matsudamper/folderviewer/viewmodel/browser/FileBrowserViewModel.kt
@@ -498,13 +498,18 @@ class FileBrowserViewModel @AssistedInject constructor(
     private fun loadStorageName() {
         viewModelScope.launch {
             val storage = storageRepository.storageList.first().find { it.id == fileObjectId.storageId }
+            val localRootPath = when (storage) {
+                is StorageConfiguration.Local -> storage.rootPath
+                is StorageConfiguration.External -> storage.rootPath
+                else -> null
+            }
             viewModelStateFlow.update { state ->
                 state.copy(
                     storageName = storage?.name ?: state.storageName,
-                    localFolderPath = if (storage is StorageConfiguration.Local) {
+                    localFolderPath = if (localRootPath != null) {
                         when (fileObjectId) {
-                            is FileObjectId.Root -> storage.rootPath
-                            is FileObjectId.Item -> "${storage.rootPath}/${fileObjectId.id}"
+                            is FileObjectId.Root -> localRootPath
+                            is FileObjectId.Item -> "$localRootPath/${fileObjectId.id}"
                         }
                     } else {
                         state.localFolderPath

--- a/viewmodel/src/main/java/net/matsudamper/folderviewer/viewmodel/home/HomeViewModel.kt
+++ b/viewmodel/src/main/java/net/matsudamper/folderviewer/viewmodel/home/HomeViewModel.kt
@@ -64,6 +64,10 @@ class HomeViewModel @Inject constructor(
                     // 何もしない
                 }
 
+                is UiStorageConfiguration.External -> {
+                    // 何もしない
+                }
+
                 is UiStorageConfiguration.SharePoint -> {
                     viewModelScope.launch {
                         viewModelEventChannel.send(ViewModelEvent.NavigateToSharePointAdd(storage.id))
@@ -100,6 +104,14 @@ class HomeViewModel @Inject constructor(
 
                                 is StorageConfiguration.Local -> {
                                     UiStorageConfiguration.Local(
+                                        id = storage.id,
+                                        name = storage.name,
+                                        rootPath = storage.rootPath,
+                                    )
+                                }
+
+                                is StorageConfiguration.External -> {
+                                    UiStorageConfiguration.External(
                                         id = storage.id,
                                         name = storage.name,
                                         rootPath = storage.rootPath,

--- a/viewmodel/src/main/java/net/matsudamper/folderviewer/viewmodel/home/StoragePickerViewModel.kt
+++ b/viewmodel/src/main/java/net/matsudamper/folderviewer/viewmodel/home/StoragePickerViewModel.kt
@@ -59,6 +59,12 @@ class StoragePickerViewModel @Inject constructor(
                 rootPath = rootPath,
             )
 
+            is StorageConfiguration.External -> UiStorageConfiguration.External(
+                id = id,
+                name = name,
+                rootPath = rootPath,
+            )
+
             is StorageConfiguration.SharePoint -> UiStorageConfiguration.SharePoint(
                 id = id,
                 name = name,


### PR DESCRIPTION
## 概要
Androidデバイスの外部ストレージ（SDカードなど）をアプリで利用できるようにしました。外部ストレージの自動検出、マウント状態の監視、ローカルストレージと同様のファイル操作に対応しています。

## 主な変更

### リポジトリ層
- **ExternalStorageRepository** を新規作成
  - `StorageManager` と `BroadcastReceiver` を使用して外部ストレージを自動検出
  - マウント/アンマウント時のイベント監視
  - 外部ストレージの一覧を `Flow<List<StorageConfiguration.External>>` で提供

- **StorageRepository** を更新
  - `externalStorages` フローと既存ストレージを `combine` して統合リストを提供
  - `isRootWritable()` で外部ストレージの書き込み可能判定に対応
  - `getFileRepository()` で外部ストレージに対応（ローカルファイルリポジトリとして処理）

- **StorageConfiguration** に `External` 型を追加
  - `id`、`name`、`rootPath` を保持

### ViewModel層
- **HomeViewModel** を更新
  - `StorageConfiguration.External` の変換処理を追加
  - 外部ストレージ選択時の処理を実装

- **FileBrowserViewModel** を更新
  - ローカルストレージと外部ストレージの両方に対応したパス表示ロジック

- **StoragePickerViewModel** を更新
  - 外部ストレージの UI 変換処理を追加

### UI層
- **UiStorageConfiguration** に `External` 型を追加

- **StorageItem** を更新
  - 外部ストレージはメニュー長押しを無効化（削除不可）
  - 外部ストレージの表示形式を追加（「外部ストレージ: パス」）

- **HomeScreenPreview** を更新
  - 外部ストレージのプレビュー例を追加

## 実装の詳細
- 外部ストレージは `StorageConfiguration.External` として管理され、ローカルストレージと同様に `LocalFileRepository` で処理
- 外部ストレージは削除不可（UI上でメニュー操作を無効化）
- マウント状態の変化を自動監視し、リアルタイムで利用可能なストレージを更新

https://claude.ai/code/session_01G2z31DAn2ZcHLC7bTCMrdk