### PR TITLE
ファイルブラウザトップバーのメニューをドロップダウンに統合

### DIFF
--- a/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileBrowserTopBar.kt
+++ b/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileBrowserTopBar.kt
@@ -69,7 +69,11 @@ internal fun FileBrowserTopBar(
             var showMoreMenu by remember { mutableStateOf(false) }
             var showDisplayMenu by remember { mutableStateOf(false) }
             var showSortMenu by remember { mutableStateOf(false) }
-            IconButton(onClick = { showMoreMenu = true }) {
+            IconButton(onClick = {
+                showDisplayMenu = false
+                showSortMenu = false
+                showMoreMenu = true
+            }) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_more_vert),
                     contentDescription = stringResource(R.string.more_options),

--- a/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileBrowserTopBar.kt
+++ b/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileBrowserTopBar.kt
@@ -85,7 +85,17 @@ internal fun FileBrowserTopBar(
             ) {
                 if (visibleFavoriteButton) {
                     DropdownMenuItem(
-                        text = { Text(stringResource(R.string.add_to_favorites)) },
+                        text = {
+                            Text(
+                                stringResource(
+                                    if (isFavorite) {
+                                        R.string.remove_from_favorites
+                                    } else {
+                                        R.string.add_to_favorites
+                                    },
+                                ),
+                            )
+                        },
                         onClick = {
                             showMoreMenu = false
                             onFavoriteClick()

--- a/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileBrowserTopBar.kt
+++ b/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileBrowserTopBar.kt
@@ -66,33 +66,84 @@ internal fun FileBrowserTopBar(
             }
         },
         actions = {
-            if (visibleFavoriteButton) {
-                IconButton(onClick = onFavoriteClick) {
-                    Icon(
-                        painter = painterResource(
-                            id = if (isFavorite) R.drawable.ic_star else R.drawable.ic_star_border,
-                        ),
-                        contentDescription = stringResource(R.string.add_to_favorites),
-                        tint = if (isFavorite) {
-                            MaterialTheme.colorScheme.primary
-                        } else {
-                            LocalContentColor.current
+            var showMoreMenu by remember { mutableStateOf(false) }
+            var showDisplayMenu by remember { mutableStateOf(false) }
+            var showSortMenu by remember { mutableStateOf(false) }
+            IconButton(onClick = { showMoreMenu = true }) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_more_vert),
+                    contentDescription = stringResource(R.string.more_options),
+                )
+            }
+            DropdownMenu(
+                expanded = showMoreMenu,
+                onDismissRequest = { showMoreMenu = false },
+            ) {
+                if (visibleFavoriteButton) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.add_to_favorites)) },
+                        onClick = {
+                            showMoreMenu = false
+                            onFavoriteClick()
+                        },
+                        leadingIcon = {
+                            Icon(
+                                painter = painterResource(
+                                    id = if (isFavorite) R.drawable.ic_star else R.drawable.ic_star_border,
+                                ),
+                                contentDescription = null,
+                                tint = if (isFavorite) {
+                                    MaterialTheme.colorScheme.primary
+                                } else {
+                                    LocalContentColor.current
+                                },
+                            )
                         },
                     )
                 }
-            }
-
-            var showDisplayMenu by remember { mutableStateOf(false) }
-            IconButton(onClick = { showDisplayMenu = true }) {
-                Icon(
-                    painter = painterResource(
-                        id = if (displayConfig.displayMode == UiDisplayConfig.DisplayMode.Grid) {
-                            R.drawable.ic_grid_view
-                        } else {
-                            R.drawable.ic_view_list
-                        },
-                    ),
-                    contentDescription = stringResource(R.string.display_mode),
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.display_mode)) },
+                    onClick = {
+                        showMoreMenu = false
+                        showDisplayMenu = true
+                    },
+                    leadingIcon = {
+                        Icon(
+                            painter = painterResource(
+                                id = if (displayConfig.displayMode == UiDisplayConfig.DisplayMode.Grid) {
+                                    R.drawable.ic_grid_view
+                                } else {
+                                    R.drawable.ic_view_list
+                                },
+                            ),
+                            contentDescription = null,
+                        )
+                    },
+                    trailingIcon = {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_chevron_right),
+                            contentDescription = null,
+                        )
+                    },
+                )
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.sort_by)) },
+                    onClick = {
+                        showMoreMenu = false
+                        showSortMenu = true
+                    },
+                    leadingIcon = {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_sort),
+                            contentDescription = null,
+                        )
+                    },
+                    trailingIcon = {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_chevron_right),
+                            contentDescription = null,
+                        )
+                    },
                 )
             }
 
@@ -102,14 +153,6 @@ internal fun FileBrowserTopBar(
                 displayConfig = displayConfig,
                 onDisplayConfigChange = onDisplayConfigChange,
             )
-
-            var showSortMenu by remember { mutableStateOf(false) }
-            IconButton(onClick = { showSortMenu = true }) {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_sort),
-                    contentDescription = stringResource(R.string.sort_by),
-                )
-            }
 
             FileBrowserSortDropDownMenu(
                 showSortMenu = showSortMenu,
@@ -196,6 +239,28 @@ internal fun FileBrowserSelectionTopBar(
                 }
             }
         },
+    )
+}
+
+@Composable
+@Preview
+private fun FileBrowserTopBarPreview() {
+    FileBrowserTopBar(
+        title = "フォルダ名",
+        isFavorite = true,
+        visibleFavoriteButton = true,
+        onBack = {},
+        sortConfig = FileBrowserUiState.FileSortConfig(
+            key = FileBrowserUiState.FileSortKey.Name,
+            isAscending = true,
+        ),
+        onSortConfigChange = {},
+        displayConfig = UiDisplayConfig(
+            displayMode = UiDisplayConfig.DisplayMode.List,
+            displaySize = UiDisplayConfig.DisplaySize.Medium,
+        ),
+        onDisplayConfigChange = {},
+        onFavoriteClick = {},
     )
 }
 

--- a/ui/src/main/res/drawable/ic_chevron_right.xml
+++ b/ui/src/main/res/drawable/ic_chevron_right.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:autoMirrored="true">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M504,480L320,296L376,240L616,480L376,720L320,664L504,480Z"/>
+</vector>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="folder">フォルダ</string>
     <string name="file">ファイル</string>
     <string name="add_to_favorites">お気に入りに追加</string>
+    <string name="remove_from_favorites">お気に入りから削除</string>
     <string name="storages">ストレージ</string>
     <string name="favorites">お気に入り</string>
     <string name="cancel_selection">選択をキャンセル</string>


### PR DESCRIPTION
## 概要
ファイルブラウザのトップバーのアクション領域を整理し、複数のアイコンボタンを1つのドロップダウンメニューに統合しました。

## 主な変更
- **メニュー構造の統合**: お気に入り、表示モード、ソート機能を「その他」ドロップダウンメニューに統合
  - 従来の個別アイコンボタンから、`ic_more_vert`アイコンの単一ボタンに変更
  - ドロップダウンメニュー内に各機能をメニューアイテムとして配置

- **UI/UX の改善**:
  - 表示モードとソート機能のメニューアイテムに右矢印アイコン(`ic_chevron_right`)を追加し、サブメニューへの遷移を視覚的に表現
  - メニューアイテムのクリック時に親メニューを自動的に閉じる処理を実装

- **新規リソース追加**:
  - `ic_chevron_right.xml`: サブメニュー遷移を示す右矢印アイコンを追加

- **プレビューの追加**:
  - `FileBrowserTopBarPreview()`を追加し、トップバーの表示状態を確認可能に

## 実装の詳細
- `showMoreMenu`、`showDisplayMenu`、`showSortMenu`の3つの状態を管理
- ドロップダウンメニュー内のメニューアイテムクリック時に、親メニューを閉じてから対応する処理を実行
- トップバーのアクション領域がより整理され、スッキリした見た目になります

https://claude.ai/code/session_017dyWigJtSwu1mPqS8bLobg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ファイルブラウザのトップバーを再構成し、表示モード切替、ソート指定、お気に入り追加機能をドロップダウンメニュー内に統合しました。操作性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->