### PR TITLE
外部アプリで開く機能をトップバーのメニューに移動

### DIFF
--- a/app/src/main/java/net/matsudamper/folderviewer/MainActivity.kt
+++ b/app/src/main/java/net/matsudamper/folderviewer/MainActivity.kt
@@ -529,10 +529,16 @@ private fun FileBrowserEventHandler(
                 }
 
                 is FileBrowserViewModel.ViewModelEvent.OpenFolderWithExternalApp -> {
-                    val uri = android.net.Uri.fromFile(File(event.path))
+                    val relativePath = File(event.path)
+                        .relativeToOrNull(android.os.Environment.getExternalStorageDirectory())
+                        ?.path
+                        .orEmpty()
+                    val uri = android.provider.DocumentsContract.buildDocumentUri(
+                        "com.android.externalstorage.documents",
+                        "primary:$relativePath",
+                    )
                     val intent = Intent(Intent.ACTION_VIEW).apply {
-                        setDataAndType(uri, "resource/folder")
-                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        setDataAndType(uri, android.provider.DocumentsContract.Document.MIME_TYPE_DIR)
                     }
                     runCatching {
                         context.startActivity(intent)

--- a/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileBrowserScreenContent.kt
+++ b/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileBrowserScreenContent.kt
@@ -89,6 +89,8 @@ internal fun FileBrowserScreenContent(
                     displayConfig = uiState.displayConfig,
                     onDisplayConfigChange = callbacks::onDisplayModeChanged,
                     onFavoriteClick = callbacks::onFavoriteClick,
+                    visibleOpenFolderWithExternalAppButton = uiState.visibleOpenFolderWithExternalAppButton,
+                    onOpenFolderWithExternalAppClick = callbacks::onOpenFolderWithExternalAppClick,
                 )
             }
         },
@@ -179,14 +181,6 @@ internal fun FileBrowserScreenContent(
                             painter = painterResource(R.drawable.ic_folder_add),
                             contentDescription = "ディレクトリを作成",
                         )
-                    }
-                    if (uiState.visibleOpenFolderWithExternalAppButton) {
-                        IconButton(onClick = { callbacks.onOpenFolderWithExternalAppClick() }) {
-                            Icon(
-                                painter = painterResource(R.drawable.ic_open_in_new),
-                                contentDescription = "外部アプリで開く",
-                            )
-                        }
                     }
                 }
             }

--- a/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileBrowserTopBar.kt
+++ b/ui/src/main/java/net/matsudamper/folderviewer/ui/browser/FileBrowserTopBar.kt
@@ -37,6 +37,8 @@ internal fun FileBrowserTopBar(
     displayConfig: UiDisplayConfig,
     onDisplayConfigChange: (UiDisplayConfig) -> Unit,
     onFavoriteClick: () -> Unit,
+    visibleOpenFolderWithExternalAppButton: Boolean,
+    onOpenFolderWithExternalAppClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
@@ -111,6 +113,21 @@ internal fun FileBrowserTopBar(
                                 } else {
                                     LocalContentColor.current
                                 },
+                            )
+                        },
+                    )
+                }
+                if (visibleOpenFolderWithExternalAppButton) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.open_folder_with_external_app)) },
+                        onClick = {
+                            showMoreMenu = false
+                            onOpenFolderWithExternalAppClick()
+                        },
+                        leadingIcon = {
+                            Icon(
+                                painter = painterResource(id = R.drawable.ic_open_in_new),
+                                contentDescription = null,
                             )
                         },
                     )
@@ -275,6 +292,8 @@ private fun FileBrowserTopBarPreview() {
         ),
         onDisplayConfigChange = {},
         onFavoriteClick = {},
+        visibleOpenFolderWithExternalAppButton = true,
+        onOpenFolderWithExternalAppClick = {},
     )
 }
 


### PR DESCRIPTION
## 概要
ファイルブラウザの「外部アプリで開く」機能をトップバーのドロップダウンメニューに移動し、インテント処理を改善しました。

## 主な変更

- **FileBrowserTopBar**: ドロップダウンメニューに「外部アプリで開く」オプションを追加
  - `visibleOpenFolderWithExternalAppButton`パラメータを追加
  - `onOpenFolderWithExternalAppClick`コールバックを追加
  - メニューアイテムに`ic_open_in_new`アイコンを表示

- **FileBrowserScreenContent**: トップバーのアクションボタンから「外部アプリで開く」ボタンを削除
  - トップバーのメニューに統合されたため、個別のボタンは不要に

- **MainActivity**: フォルダを開くインテント処理を改善
  - `File.fromFile()`から`DocumentsContract.buildDocumentUri()`に変更
  - 相対パスを計算して`primary:`スキームで指定
  - MIMEタイプを`resource/folder`から`DocumentsContract.Document.MIME_TYPE_DIR`に変更
  - `FLAG_GRANT_READ_URI_PERMISSION`フラグを削除

## 実装の詳細
外部ストレージのドキュメントプロバイダーを使用することで、より適切なファイルマネージャーの統合を実現しています。

https://claude.ai/code/session_01BzTVVLNB2xWQaAmrELRTES