### PR TITLE
外部ストレージの検出方法をAPI 30以上に対応させる

### DIFF
--- a/repository/src/main/java/net/matsudamper/folderviewer/repository/ExternalStorageRepository.kt
+++ b/repository/src/main/java/net/matsudamper/folderviewer/repository/ExternalStorageRepository.kt
@@ -4,8 +4,10 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.os.Build
 import android.os.Environment
 import android.os.storage.StorageManager
+import android.os.storage.StorageVolume
 import androidx.core.content.ContextCompat
 import dagger.hilt.android.qualifiers.ApplicationContext
 import jakarta.inject.Inject
@@ -35,8 +37,26 @@ class ExternalStorageRepository @Inject constructor(
             addDataScheme("file")
         }
         ContextCompat.registerReceiver(context, receiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
+        val volumeCallback = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val storageManager = context.getSystemService(StorageManager::class.java)
+            val callback = object : StorageManager.StorageVolumeCallback() {
+                override fun onStateChanged(volume: StorageVolume) {
+                    trySend(loadExternalStorages())
+                }
+            }
+            storageManager?.registerStorageVolumeCallback(context.mainExecutor, callback)
+            callback
+        } else {
+            null
+        }
         trySend(loadExternalStorages())
-        awaitClose { context.unregisterReceiver(receiver) }
+        awaitClose {
+            context.unregisterReceiver(receiver)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && volumeCallback != null) {
+                context.getSystemService(StorageManager::class.java)
+                    ?.unregisterStorageVolumeCallback(volumeCallback)
+            }
+        }
     }.distinctUntilChanged()
 
     fun findExternalStorage(id: StorageId): StorageConfiguration.External? {
@@ -46,20 +66,35 @@ class ExternalStorageRepository @Inject constructor(
     private fun loadExternalStorages(): List<StorageConfiguration.External> {
         val storageManager = context.getSystemService(StorageManager::class.java)
             ?: return emptyList()
-        return context.getExternalFilesDirs(null)
-            .filterNotNull()
-            .mapNotNull { filesDir ->
-                val volume = storageManager.getStorageVolume(filesDir) ?: return@mapNotNull null
+        return storageManager.storageVolumes
+            .mapNotNull { volume ->
                 if (!volume.isRemovable) return@mapNotNull null
-                if (volume.state != Environment.MEDIA_MOUNTED) return@mapNotNull null
+                if (volume.state != Environment.MEDIA_MOUNTED &&
+                    volume.state != Environment.MEDIA_MOUNTED_READ_ONLY
+                ) {
+                    return@mapNotNull null
+                }
                 val uuid = volume.uuid ?: return@mapNotNull null
+                val rootPath = getVolumeRootPath(storageManager, volume) ?: return@mapNotNull null
                 StorageConfiguration.External(
                     id = StorageId("$ExternalStorageIdPrefix$uuid"),
                     name = volume.getDescription(context) ?: DefaultExternalStorageName,
-                    rootPath = filesDir.absolutePath.substringBefore("/Android/"),
+                    rootPath = rootPath,
                 )
             }
             .distinctBy { it.id }
+    }
+
+    private fun getVolumeRootPath(storageManager: StorageManager, volume: StorageVolume): String? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            volume.directory?.absolutePath
+        } else {
+            context.getExternalFilesDirs(null)
+                .filterNotNull()
+                .firstOrNull { storageManager.getStorageVolume(it) == volume }
+                ?.absolutePath
+                ?.substringBefore("/Android/")
+        }
     }
 
     companion object {


### PR DESCRIPTION
## 概要
外部ストレージの検出・監視方法をAndroid 11（API 30）以上に対応させました。新しいStorageManager APIを使用して、より信頼性の高いストレージボリューム検出を実現します。

## 主な変更点
- **StorageVolumeCallback の導入**: Android 11以上でStorageManager.StorageVolumeCallbackを使用し、ストレージボリュームの状態変化をリアルタイムで監視
- **ストレージボリューム取得方法の改善**: 従来のgetExternalFilesDirs()からstorageManager.storageVolumesへ変更し、より直接的にボリューム情報を取得
- **読み取り専用マウント状態への対応**: MEDIA_MOUNTED_READ_ONLYの状態も有効なストレージとして認識
- **バージョン別の実装分岐**: getVolumeRootPath()メソッドを新設し、API 30以上ではvolume.directoryを、それ以下ではgetExternalFilesDirs()を使用
- **リソースの適切なクリーンアップ**: awaitClose内でStorageVolumeCallbackの登録解除を実装

## 実装の詳細
- Build.VERSION.SDK_INTを使用したバージョン判定により、古いAndroidバージョンとの互換性を維持
- StorageVolumeCallbackはmainExecutorで登録し、UIスレッドでの実行を保証
- distinctUntilChanged()により、重複した状態変化の通知を防止

https://claude.ai/code/session_01NjLvHj22pVqTeuLHjZgNVi