### PR TITLE
履歴クリア時に一時停止中・重複解決待ちも削除する

### DIFF
--- a/repository/src/main/java/net/matsudamper/folderviewer/repository/db/OperationDao.kt
+++ b/repository/src/main/java/net/matsudamper/folderviewer/repository/db/OperationDao.kt
@@ -41,7 +41,7 @@ internal interface OperationDao {
     suspend fun isPauseRequested(id: Long): Boolean
 
     @Query(
-        "DELETE FROM operations WHERE status NOT IN ('RUNNING', 'ENQUEUED', 'PAUSED', 'WAITING_RESOLUTION')",
+        "DELETE FROM operations WHERE status NOT IN ('RUNNING', 'ENQUEUED')",
     )
     suspend fun deleteNonActive()
 


### PR DESCRIPTION
## 概要
- 「履歴をクリア」実行時に、`PAUSED`（一時停止中）と`WAITING_RESOLUTION`（重複解決待ち）のステータスも削除対象に含めるよう変更
- 変更前: `RUNNING`, `ENQUEUED`, `PAUSED`, `WAITING_RESOLUTION` を保持
- 変更後: `RUNNING`, `ENQUEUED` のみ保持（実際に動作中のもののみ残す）

## テストプラン
- [ ] 一時停止中のアップロード操作がある状態で「履歴をクリア」を実行し、削除されることを確認
- [ ] 重複解決待ちのアップロード操作がある状態で「履歴をクリア」を実行し、削除されることを確認
- [ ] 実行中・キュー待ちの操作は「履歴をクリア」で削除されないことを確認

https://claude.ai/code/session_01YJE8ALY7BHW1qyij24T3SG

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJE8ALY7BHW1qyij24T3SG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 操作ステータスの削除ロジックを修正しました。非アクティブな操作の削除条件を調整し、より適切なステータスの操作を削除対象とするようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->