### PR TITLE
外部ファイルピッカーの表示モード・ソート設定を独立保持

### DIFF
--- a/repository/src/main/java/net/matsudamper/folderviewer/repository/PreferencesRepository.kt
+++ b/repository/src/main/java/net/matsudamper/folderviewer/repository/PreferencesRepository.kt
@@ -15,6 +15,7 @@ import jakarta.inject.Inject
 import jakarta.inject.Singleton
 import net.matsudamper.folderviewer.repository.proto.BrowserDisplayMode
 import net.matsudamper.folderviewer.repository.proto.BrowserPreferencesProto
+import net.matsudamper.folderviewer.repository.proto.ExternalPickerDisplayConfig
 import net.matsudamper.folderviewer.repository.proto.FileBrowserDisplayConfig
 import net.matsudamper.folderviewer.repository.proto.FolderBrowserDisplayConfig
 import net.matsudamper.folderviewer.repository.proto.SortConfigProto
@@ -53,6 +54,16 @@ class PreferencesRepository @Inject constructor(
     val fileBrowserDisplayMode: Flow<DisplayMode> = context.browserPreferencesDataStore.data
         .map { proto ->
             proto.fileBrowserDisplayConfig.displayMode.toDisplayMode()
+        }
+
+    val externalPickerSortConfig: Flow<FileSortConfig> = context.browserPreferencesDataStore.data
+        .map { proto ->
+            proto.externalPickerDisplayConfig.sortConfig.toDomain()
+        }
+
+    val externalPickerDisplayMode: Flow<DisplayMode> = context.browserPreferencesDataStore.data
+        .map { proto ->
+            proto.externalPickerDisplayConfig.displayMode.toDisplayMode()
         }
 
     suspend fun saveFolderBrowserFolderSortConfig(config: FileSortConfig) {
@@ -108,6 +119,30 @@ class PreferencesRepository @Inject constructor(
             currentPrefs.toBuilder()
                 .setFileBrowserDisplayConfig(
                     currentPrefs.fileBrowserDisplayConfig.toBuilder()
+                        .setDisplayMode(mode.toProto())
+                        .build(),
+                )
+                .build()
+        }
+    }
+
+    suspend fun saveExternalPickerSortConfig(config: FileSortConfig) {
+        context.browserPreferencesDataStore.updateData { currentPrefs ->
+            currentPrefs.toBuilder()
+                .setExternalPickerDisplayConfig(
+                    currentPrefs.externalPickerDisplayConfig.toBuilder()
+                        .setSortConfig(config.toProto())
+                        .build(),
+                )
+                .build()
+        }
+    }
+
+    suspend fun saveExternalPickerDisplayMode(mode: DisplayMode) {
+        context.browserPreferencesDataStore.updateData { currentPrefs ->
+            currentPrefs.toBuilder()
+                .setExternalPickerDisplayConfig(
+                    currentPrefs.externalPickerDisplayConfig.toBuilder()
                         .setDisplayMode(mode.toProto())
                         .build(),
                 )
@@ -193,6 +228,17 @@ internal object BrowserPreferencesSerializer : Serializer<BrowserPreferencesProt
         )
         .setFileBrowserDisplayConfig(
             FileBrowserDisplayConfig.newBuilder()
+                .setSortConfig(
+                    SortConfigProto.newBuilder()
+                        .setKey(SortConfigProto.SortKey.NAME)
+                        .setIsAscending(true)
+                        .build(),
+                )
+                .setDisplayMode(BrowserDisplayMode.LIST)
+                .build(),
+        )
+        .setExternalPickerDisplayConfig(
+            ExternalPickerDisplayConfig.newBuilder()
                 .setSortConfig(
                     SortConfigProto.newBuilder()
                         .setKey(SortConfigProto.SortKey.NAME)

--- a/repository/src/main/proto/browser_preferences.proto
+++ b/repository/src/main/proto/browser_preferences.proto
@@ -6,6 +6,12 @@ option java_multiple_files = true;
 message BrowserPreferencesProto {
   FolderBrowserDisplayConfig folder_browser_display_config = 1;
   FileBrowserDisplayConfig file_browser_display_config = 2;
+  ExternalPickerDisplayConfig external_picker_display_config = 3;
+}
+
+message ExternalPickerDisplayConfig {
+  SortConfigProto sort_config = 1;
+  BrowserDisplayMode display_mode = 2;
 }
 
 message FolderBrowserDisplayConfig {

--- a/viewmodel/src/main/java/net/matsudamper/folderviewer/viewmodel/picker/ExternalFilePickerViewModel.kt
+++ b/viewmodel/src/main/java/net/matsudamper/folderviewer/viewmodel/picker/ExternalFilePickerViewModel.kt
@@ -75,7 +75,7 @@ class ExternalFilePickerViewModel @AssistedInject constructor(
         override fun onSortConfigChanged(config: FileBrowserUiState.FileSortConfig) {
             viewModelStateFlow.update { it.copy(sortConfig = config) }
             viewModelScope.launch {
-                preferencesRepository.saveFileBrowserSortConfig(
+                preferencesRepository.saveExternalPickerSortConfig(
                     PreferencesRepository.FileSortConfig(
                         key = when (config.key) {
                             FileBrowserUiState.FileSortKey.Name -> PreferencesRepository.FileSortKey.Name
@@ -91,7 +91,7 @@ class ExternalFilePickerViewModel @AssistedInject constructor(
         override fun onDisplayModeChanged(config: UiDisplayConfig) {
             viewModelStateFlow.update { it.copy(displayConfig = config) }
             viewModelScope.launch {
-                preferencesRepository.saveFileBrowserDisplayMode(
+                preferencesRepository.saveExternalPickerDisplayMode(
                     when (config.displayMode) {
                         UiDisplayConfig.DisplayMode.List -> PreferencesRepository.DisplayMode.List
                         UiDisplayConfig.DisplayMode.Grid -> PreferencesRepository.DisplayMode.Grid
@@ -251,7 +251,7 @@ class ExternalFilePickerViewModel @AssistedInject constructor(
     }
 
     private suspend fun loadSortConfig() {
-        preferencesRepository.fileBrowserSortConfig.collect { config ->
+        preferencesRepository.externalPickerSortConfig.collect { config ->
             viewModelStateFlow.update {
                 it.copy(
                     sortConfig = FileBrowserUiState.FileSortConfig(
@@ -268,7 +268,7 @@ class ExternalFilePickerViewModel @AssistedInject constructor(
     }
 
     private suspend fun loadDisplayMode() {
-        preferencesRepository.fileBrowserDisplayMode.collect { displayMode ->
+        preferencesRepository.externalPickerDisplayMode.collect { displayMode ->
             viewModelStateFlow.update {
                 it.copy(
                     displayConfig = UiDisplayConfig(


### PR DESCRIPTION
## 概要
- 外部ファイルピッカーがFileBrowserと表示モード・ソート設定を共有していたのを分離
- `ExternalPickerDisplayConfig`をProtoに新設し、専用のDataStore設定として保持するように変更

## 変更内容
- `browser_preferences.proto`: `ExternalPickerDisplayConfig`メッセージを追加し、`BrowserPreferencesProto`にフィールド追加
- `PreferencesRepository`: 外部ピッカー用の`externalPickerSortConfig`/`externalPickerDisplayMode`のFlow・save関数を追加
- `ExternalFilePickerViewModel`: `fileBrowser*`の設定参照を`externalPicker*`に切り替え

## テスト計画
- [ ] ビルドが通ること（確認済み）
- [ ] 外部ファイルピッカーで表示モード・ソートを変更しても、通常のFileBrowserの設定に影響しないこと
- [ ] 通常のFileBrowserで表示モード・ソートを変更しても、外部ファイルピッカーの設定に影響しないこと
- [ ] アプリ再起動後も外部ファイルピッカーの設定が保持されること

https://claude.ai/code/session_014QA8JVePU6dMvAKW7om5tN

---
_Generated by [Claude Code](https://claude.ai/code/session_014QA8JVePU6dMvAKW7om5tN)_