### PR TITLE
ビルドバージョンコードをハードコード化

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,7 +15,7 @@ android {
         minSdk = 28
         targetSdk = 36
         val ciVersion = System.getenv("VERSION")?.toIntOrNull()
-        versionCode = ciVersion ?: 1
+        versionCode = 1
         versionName = if (ciVersion != null) "Release-$ciVersion" else "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
## 概要
CI環境変数に依存していたバージョンコードの設定をハードコード化しました。

## 変更内容
- `versionCode`を常に`1`に固定しました
  - 変更前：`versionCode = ciVersion ?: 1`（CI環境変数`VERSION`があればそれを使用、なければ1）
  - 変更後：`versionCode = 1`（常に1）
- `versionName`はCI環境変数に基づいた動的な設定のままです

## 備考
この変更により、ビルド時のCI環境変数の有無に関わらず、バージョンコードは常に`1`となります。

https://claude.ai/code/session_01JhSJmNZpnfZQ47R6twRcf4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ビルド設定のバージョン管理方式を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->