### PR TITLE
予測的ジェスチャーバック中のページスワイプを無効化

### DIFF
--- a/app/src/main/java/net/matsudamper/folderviewer/MainActivity.kt
+++ b/app/src/main/java/net/matsudamper/folderviewer/MainActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.PredictiveBackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -145,6 +146,15 @@ private fun AppContent(
     modifier: Modifier = Modifier,
 ) {
     val pagerState = rememberPagerState { 2 }
+    var isPredictiveBackInProgress by remember { mutableStateOf(false) }
+    PredictiveBackHandler(enabled = true) { progress ->
+        isPredictiveBackInProgress = true
+        try {
+            progress.collect { }
+        } finally {
+            isPredictiveBackInProgress = false
+        }
+    }
 
     Box(
         modifier = modifier.fillMaxSize(),
@@ -156,6 +166,7 @@ private fun AppContent(
                 .fillMaxSize()
                 .edgeSwipeGuard(),
             state = pagerState,
+            userScrollEnabled = !isPredictiveBackInProgress,
         ) { pageIndex ->
             holder.SaveableStateProvider("Root_$pageIndex") {
                 val pageViewModelStoreOwner = rememberPageViewModelStoreOwner(pageIndex = pageIndex)

--- a/app/src/main/java/net/matsudamper/folderviewer/MainActivity.kt
+++ b/app/src/main/java/net/matsudamper/folderviewer/MainActivity.kt
@@ -53,7 +53,6 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.unit.dp
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
@@ -62,6 +61,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.viewModel

--- a/app/src/main/java/net/matsudamper/folderviewer/MainActivity.kt
+++ b/app/src/main/java/net/matsudamper/folderviewer/MainActivity.kt
@@ -3,8 +3,10 @@ package net.matsudamper.folderviewer
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
+import androidx.activity.BackEventCompat
 import androidx.activity.ComponentActivity
-import androidx.activity.compose.PredictiveBackHandler
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -33,6 +35,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
@@ -50,6 +53,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.unit.dp
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
@@ -147,13 +151,29 @@ private fun AppContent(
 ) {
     val pagerState = rememberPagerState { 2 }
     var isPredictiveBackInProgress by remember { mutableStateOf(false) }
-    PredictiveBackHandler(enabled = true) { progress ->
-        isPredictiveBackInProgress = true
-        try {
-            progress.collect { }
-        } finally {
-            isPredictiveBackInProgress = false
+    val backDispatcherOwner = LocalOnBackPressedDispatcherOwner.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(backDispatcherOwner, lifecycleOwner) {
+        if (backDispatcherOwner == null) return@DisposableEffect onDispose { }
+        val dispatcher = backDispatcherOwner.onBackPressedDispatcher
+        val callback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackStarted(backEvent: BackEventCompat) {
+                isPredictiveBackInProgress = true
+            }
+
+            override fun handleOnBackCancelled() {
+                isPredictiveBackInProgress = false
+            }
+
+            override fun handleOnBackPressed() {
+                isPredictiveBackInProgress = false
+                isEnabled = false
+                dispatcher.onBackPressed()
+                isEnabled = true
+            }
         }
+        dispatcher.addCallback(lifecycleOwner, callback)
+        onDispose { callback.remove() }
     }
 
     Box(


### PR DESCRIPTION
## 概要
Android 14以降の予測的ジェスチャーバック機能に対応し、バック操作中のページスワイプを無効化しました。

## 変更内容
- `PredictiveBackHandler`を導入し、予測的バック操作の進行状況を追跡
- `isPredictiveBackInProgress`状態フラグを追加して、バック操作中であることを管理
- `HorizontalPager`の`userScrollEnabled`を制御し、バック操作中はユーザースワイプを無効化

## 実装の詳細
予測的バック操作が進行中の場合、ページスワイプを無効にすることで、バックジェスチャーとページ切り替えジェスチャーの競合を防止しています。

https://claude.ai/code/session_01GZkZiwvwVenXraYMdznPzk