### PR TITLE
外部アプリでファイルを開く機能をFolderBrowserViewModelに追加

### DIFF
--- a/app/src/main/java/net/matsudamper/folderviewer/MainActivity.kt
+++ b/app/src/main/java/net/matsudamper/folderviewer/MainActivity.kt
@@ -668,49 +668,63 @@ private fun FileBrowserEventHandler(
                 }
 
                 is FileBrowserViewModel.ViewModelEvent.OpenWithExternalPlayer -> {
-                    val uri = when (val externalUri = event.viewSourceUri) {
-                        is ViewSourceUri.LocalFile -> {
-                            FileProvider.getUriForFile(
-                                context,
-                                "${context.packageName}.fileprovider",
-                                File(externalUri.path),
-                            )
-                        }
-
-                        is ViewSourceUri.RemoteUrl -> {
-                            externalUri.url.toUri()
-                        }
-
-                        is ViewSourceUri.StreamProvider -> {
-                            StreamingContentProvider.buildUri(
-                                fileId = externalUri.fileId,
-                                fileName = event.fileName,
-                            )
-                        }
-                    }
-                    val isApk = event.mimeType == "application/vnd.android.package-archive"
-                    if (isApk && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O &&
-                        !context.packageManager.canRequestPackageInstalls()
-                    ) {
-                        runCatching {
-                            context.startActivity(
-                                Intent(android.provider.Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES).apply {
-                                    data = android.net.Uri.parse("package:${context.packageName}")
-                                },
-                            )
-                        }
-                        return@collect
-                    }
-                    val intent = Intent(Intent.ACTION_VIEW).apply {
-                        setDataAndType(uri, event.mimeType ?: "*/*")
-                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                    }
-                    runCatching {
-                        context.startActivity(intent)
-                    }
+                    openWithExternalApp(
+                        context = context,
+                        viewSourceUri = event.viewSourceUri,
+                        fileName = event.fileName,
+                        mimeType = event.mimeType,
+                    )
                 }
             }
         }
+    }
+}
+
+private fun openWithExternalApp(
+    context: android.content.Context,
+    viewSourceUri: ViewSourceUri,
+    fileName: String,
+    mimeType: String?,
+) {
+    val uri = when (viewSourceUri) {
+        is ViewSourceUri.LocalFile -> {
+            FileProvider.getUriForFile(
+                context,
+                "${context.packageName}.fileprovider",
+                File(viewSourceUri.path),
+            )
+        }
+
+        is ViewSourceUri.RemoteUrl -> {
+            viewSourceUri.url.toUri()
+        }
+
+        is ViewSourceUri.StreamProvider -> {
+            StreamingContentProvider.buildUri(
+                fileId = viewSourceUri.fileId,
+                fileName = fileName,
+            )
+        }
+    }
+    val isApk = mimeType == "application/vnd.android.package-archive"
+    if (isApk && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O &&
+        !context.packageManager.canRequestPackageInstalls()
+    ) {
+        runCatching {
+            context.startActivity(
+                Intent(android.provider.Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES).apply {
+                    data = android.net.Uri.parse("package:${context.packageName}")
+                },
+            )
+        }
+        return
+    }
+    val intent = Intent(Intent.ACTION_VIEW).apply {
+        setDataAndType(uri, mimeType ?: "*/*")
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    }
+    runCatching {
+        context.startActivity(intent)
     }
 }
 
@@ -812,6 +826,7 @@ private fun EntryProviderScope<NavKey>.folderBrowserEntry(navigator: Navigator) 
         )
         val uiState = viewModel.uiState.collectAsStateWithLifecycle(initialValue = null)
         val uiStateValue = uiState.value ?: return@entry
+        val context = LocalContext.current
 
         LaunchedEffect(viewModel.viewModelEventFlow) {
             viewModel.viewModelEventFlow.collect { event ->
@@ -844,6 +859,15 @@ private fun EntryProviderScope<NavKey>.folderBrowserEntry(navigator: Navigator) 
                                 fileId = event.fileId,
                                 displayPath = event.displayPath,
                             ),
+                        )
+                    }
+
+                    is FolderBrowserViewModel.ViewModelEvent.OpenWithExternalPlayer -> {
+                        openWithExternalApp(
+                            context = context,
+                            viewSourceUri = event.viewSourceUri,
+                            fileName = event.fileName,
+                            mimeType = event.mimeType,
                         )
                     }
                 }

--- a/viewmodel/src/main/java/net/matsudamper/folderviewer/viewmodel/folder/FolderBrowserUiStateCreator.kt
+++ b/viewmodel/src/main/java/net/matsudamper/folderviewer/viewmodel/folder/FolderBrowserUiStateCreator.kt
@@ -18,6 +18,7 @@ class FolderBrowserUiStateCreator(
     private val fileObjectId: FileObjectId,
     private val viewModelEventChannel: Channel<ViewModelEvent>,
     private val displayPath: String?,
+    private val onOpenWithExternalPlayer: (FileItem) -> Unit,
 ) {
     fun create(
         viewModelState: FolderBrowserViewModel.ViewModelState,
@@ -156,23 +157,31 @@ class FolderBrowserUiStateCreator(
         private val allImagePaths: List<FileObjectId.Item>,
     ) : FolderBrowserUiState.UiFileItem.File.Callbacks {
         override fun onClick() {
-            viewModelScope.launch {
-                val isImage = FileUtil.isImage(file.displayPath)
-                if (file.isDirectory) {
-                    viewModelEventChannel.send(
-                        ViewModelEvent.NavigateToFolderBrowser(
-                            fileId = file.id,
-                            displayPath = file.displayPath,
-                        ),
-                    )
-                } else if (isImage) {
-                    viewModelEventChannel.send(
-                        ViewModelEvent.NavigateToImageViewer(
-                            fileId = file.id,
-                            allPaths = allImagePaths,
-                        ),
-                    )
+            val isImage = FileUtil.isImage(file.displayPath)
+            when {
+                file.isDirectory -> {
+                    viewModelScope.launch {
+                        viewModelEventChannel.send(
+                            ViewModelEvent.NavigateToFolderBrowser(
+                                fileId = file.id,
+                                displayPath = file.displayPath,
+                            ),
+                        )
+                    }
                 }
+
+                isImage -> {
+                    viewModelScope.launch {
+                        viewModelEventChannel.send(
+                            ViewModelEvent.NavigateToImageViewer(
+                                fileId = file.id,
+                                allPaths = allImagePaths,
+                            ),
+                        )
+                    }
+                }
+
+                else -> onOpenWithExternalPlayer(file)
             }
         }
     }

--- a/viewmodel/src/main/java/net/matsudamper/folderviewer/viewmodel/folder/FolderBrowserViewModel.kt
+++ b/viewmodel/src/main/java/net/matsudamper/folderviewer/viewmodel/folder/FolderBrowserViewModel.kt
@@ -29,10 +29,12 @@ import net.matsudamper.folderviewer.repository.FileItem
 import net.matsudamper.folderviewer.repository.FileRepository
 import net.matsudamper.folderviewer.repository.PreferencesRepository
 import net.matsudamper.folderviewer.repository.StorageRepository
+import net.matsudamper.folderviewer.repository.ViewSourceUri
 import net.matsudamper.folderviewer.ui.browser.UiDisplayConfig
 import net.matsudamper.folderviewer.ui.folder.FolderBrowserUiEvent
 import net.matsudamper.folderviewer.ui.folder.FolderBrowserUiState
 import net.matsudamper.folderviewer.viewmodel.util.FileSortComparator
+import net.matsudamper.folderviewer.viewmodel.util.FileUtil
 
 @HiltViewModel(assistedFactory = FolderBrowserViewModel.Companion.Factory::class)
 class FolderBrowserViewModel @AssistedInject constructor(
@@ -128,6 +130,7 @@ class FolderBrowserViewModel @AssistedInject constructor(
         fileObjectId = arg.fileId,
         displayPath = arg.displayPath,
         viewModelEventChannel = viewModelEventChannel,
+        onOpenWithExternalPlayer = { fileItem -> openWithExternalPlayer(fileItem) },
     )
 
     val uiState: Flow<FolderBrowserUiState> = channelFlow {
@@ -250,6 +253,31 @@ class FolderBrowserViewModel @AssistedInject constructor(
         return newRepo
     }
 
+    private fun openWithExternalPlayer(fileItem: FileItem) {
+        viewModelScope.launch {
+            runCatching {
+                val repository = getRepository()
+                viewModelEventChannel.send(
+                    ViewModelEvent.OpenWithExternalPlayer(
+                        viewSourceUri = repository.getViewSourceUri(fileItem.id),
+                        fileId = fileItem.id,
+                        fileName = fileItem.displayPath,
+                        mimeType = FileUtil.getMimeType(fileItem.displayPath),
+                    ),
+                )
+            }.onFailure { e ->
+                when (e) {
+                    is CancellationException -> throw e
+
+                    else -> {
+                        e.printStackTrace()
+                        uiChannelEvent.trySend(FolderBrowserUiEvent.ShowSnackbar("外部プレイヤーで開けませんでした: ${e.message}"))
+                    }
+                }
+            }
+        }
+    }
+
     private fun refresh() {
         fetchJob?.cancel()
         fetchJob = viewModelScope.launch {
@@ -350,6 +378,13 @@ class FolderBrowserViewModel @AssistedInject constructor(
         data class NavigateToFolderBrowser(
             val fileId: FileObjectId.Item,
             val displayPath: String?,
+        ) : ViewModelEvent
+
+        data class OpenWithExternalPlayer(
+            val viewSourceUri: ViewSourceUri,
+            val fileId: FileObjectId.Item,
+            val fileName: String,
+            val mimeType: String?,
         ) : ViewModelEvent
     }
 


### PR DESCRIPTION
## 概要
FolderBrowserViewModelで外部アプリでファイルを開く機能を実装し、ディレクトリと画像以外のファイルをタップした際に外部プレイヤーで開けるようにしました。

## 主な変更点

- **openWithExternalApp関数の抽出**: FileBrowserEventHandlerの外部アプリ起動ロジックを独立した関数に抽出し、再利用可能にしました
- **FolderBrowserViewModelに外部アプリ起動機能を追加**: 
  - `openWithExternalPlayer`メソッドを実装し、ファイルアイテムから必要な情報を取得して`OpenWithExternalPlayer`イベントを発行
  - ViewModelEvent.OpenWithExternalPlayerを新規追加
- **FolderBrowserUiStateCreatorの改善**:
  - `onOpenWithExternalPlayer`コールバックを追加し、ファイルクリック時の処理を整理
  - ファイルクリック時の分岐ロジックを改善（ディレクトリ、画像、その他ファイルで異なる処理を実行）
- **folderBrowserEntry関数の更新**: OpenWithExternalPlayerイベントを処理するハンドラーを追加

## 実装の詳細

- ファイルクリック時に、ディレクトリなら階層移動、画像なら画像ビューアーへ遷移、その他ファイルなら外部アプリで開く処理を実行
- エラーハンドリングを実装し、失敗時はスナックバーでユーザーに通知
- APKファイルの場合は既存の権限チェック処理を適用

https://claude.ai/code/session_01XXUrEKngMsfRrkZp7o1WZ6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 画像やフォルダー以外のファイルをタップすると、対応する外部アプリで開けるようになりました。
  * APKファイルを開く際、必要に応じてインストール許可設定へ案内します。

* **不具合修正**
  * 外部アプリでファイルを開けない場合に、エラーを通知できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->